### PR TITLE
Make JQuery reference scheme-agnostic

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
 
 
 	
-	<script src="http://code.jquery.com/jquery-latest.min.js"></script>
+	<script src="//code.jquery.com/jquery-latest.min.js"></script>
 	<script type="text/javascript" src="js/jquery.onepage-scroll.min.js"></script>
 	<script type="text/javascript" src="js/prism.js"></script>
 	<script type="text/javascript" src="js/splitchar.js"></script>


### PR DESCRIPTION
FF29/Chrome36 refuse to load jquery from non-https url specified when page is fetched over https (error: "[blocked] The page at 'https://emisfera.github.io/Splitchar.js/' was loaded over HTTPS, but ran insecure content from 'http://code.jquery.com/jquery-latest.min.js': this content should also be loaded over HTTPS.")

Discovered by accident with https-everywhere plugin forcing https on github.io pages.
